### PR TITLE
Implement GitLabProvider for notifications from e.g. Merge-Requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ These plugins require GoCD version >= v15.x or above
 
 ## Configuration
 
-- You will see `Github Pull Requests status notifier` / `Stash Pull Requests status notifier` / `Gerrit Change Set status notifier` on plugin listing page
+- You will see `Github Pull Requests status notifier` / `Stash Pull Requests status notifier` / `Gerrit Change Set status notifier` / `GitLab Merge Requests status notifier` on plugin listing page
 ![Plugins listing page][1]
 
 - You can configure the plugin (this feature requires GoCD version >= v15.2, use system properties to configure the plugin)
@@ -93,6 +93,18 @@ Eg:
 -Dgo.plugin.build.status.gerrit.username=johndoe
 -Dgo.plugin.build.status.gerrit.password=thisaintapassword
 ```
+
+#### GitLab
+**Setup:**
+- You need to provide `endpoint` and the [`token` from your profile page](https://gitlab.com/profile/account).
+- The `token` is not really `oauth` but the custom authentication from GitLab.
+
+Eg:
+```
+-Dgo.plugin.build.status.gitlab.endpoint=https://gitlab.com/
+-Dgo.plugin.build.status.gitlab.oauth=YOUR_TOKEN_HERE
+```
+
 
 ## FAQs
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tw.go.plugin</groupId>
     <artifactId>gocd-build-status-notifier</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.2</version>
 
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
@@ -52,12 +52,6 @@
             <artifactId>java-gitlab-api</artifactId>
             <version>1.2.4</version>
         </dependency>
-        <!-- <dependency>
-            <groupId>com.messners</groupId>
-            <artifactId>gitlab-api</artifactId>
-            <version>2.0.4</version>
-        </dependency>
-        -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tw.go.plugin</groupId>
     <artifactId>gocd-build-status-notifier</artifactId>
-    <version>1.1</version>
+    <version>1.2-SNAPSHOT</version>
 
     <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <go.version>14.4.0</go.version>
+        <go.version>15.1.0</go.version>
         <main.dir>${project.basedir}</main.dir>
     </properties>
 
@@ -36,11 +38,26 @@
             <version>4.5</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
             <version>1.68</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.gitlab</groupId>
+            <artifactId>java-gitlab-api</artifactId>
+            <version>1.2.4</version>
+        </dependency>
+        <!-- <dependency>
+            <groupId>com.messners</groupId>
+            <artifactId>gitlab-api</artifactId>
+            <version>2.0.4</version>
+        </dependency>
+        -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
@@ -80,13 +97,21 @@
                 <resource.directory>src/main/resources/gerrit</resource.directory>
             </properties>
         </profile>
+        <profile>
+            <id>gitlab.mr.status</id>
+            <properties>
+                <plugin.name>gitlab-mr-status</plugin.name>
+                <resource.directory>src/main/resources/gitlab</resource.directory>
+            </properties>
+        </profile>
     </profiles>
 
     <build>
-        <finalName>${plugin.name}-${version}</finalName>
+        <finalName>${plugin.name}-${project.version}</finalName>
         <resources>
             <resource>
                 <directory>${resource.directory}</directory>
+                <filtering>true</filtering>
             </resource>
             <resource>
                 <directory>src/main/resources/common</directory>
@@ -98,10 +123,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/release.sh
+++ b/release.sh
@@ -10,3 +10,6 @@ cp target/stash-pr-status*.jar dist/
 
 mvn clean install -DskipTests -P gerrit.cs.status
 cp target/gerrit-cs-status*.jar dist/
+
+mvn clean install -DskipTests -P gitlab.mr.status
+cp target/gitlab-mr-status*.jar dist/

--- a/src/main/java/com/tw/go/plugin/provider/github/GitHubProvider.java
+++ b/src/main/java/com/tw/go/plugin/provider/github/GitHubProvider.java
@@ -24,7 +24,7 @@ public class GitHubProvider implements Provider {
     @Override
     public void updateStatus(String url, PluginSettings pluginSettings, String prIdStr, String revision, String pipelineStage,
                              String result, String trackbackURL) throws Exception {
-        String repository = getRepository(url);
+        String repository = StringUtils.getRepository(url);
         GHCommitState state = getState(result);
 
         String endPointToUse = pluginSettings.getEndPoint();
@@ -75,20 +75,6 @@ public class GitHubProvider implements Provider {
             github = GitHub.connect();
         }
         return github;
-    }
-
-    String getRepository(String url) {
-        String[] urlParts = url.split("/");
-        String repo = urlParts[urlParts.length - 1];
-        String usernameWithSSHPrefix = urlParts[urlParts.length - 2];
-        int positionOfColon = usernameWithSSHPrefix.lastIndexOf(":");
-        if (positionOfColon > 0) {
-            usernameWithSSHPrefix = usernameWithSSHPrefix.substring(positionOfColon + 1);
-        }
-
-        String urlWithoutPrefix = String.format("%s/%s", usernameWithSSHPrefix, repo);
-        if (urlWithoutPrefix.endsWith(".git")) return urlWithoutPrefix.substring(0, urlWithoutPrefix.length() - 4);
-        else return urlWithoutPrefix;
     }
 
     GHCommitState getState(String result) {

--- a/src/main/java/com/tw/go/plugin/provider/gitlab/GitLabCommitState.java
+++ b/src/main/java/com/tw/go/plugin/provider/gitlab/GitLabCommitState.java
@@ -1,0 +1,25 @@
+package com.tw.go.plugin.provider.gitlab;
+
+import java.util.Locale;
+
+enum GitLabCommitState {
+    pending,
+    running,
+    success,
+    failed,
+    canceled;
+
+    static GitLabCommitState getState(final String result) {
+        final String lcResult = result == null ? "" : result.toLowerCase(Locale.ENGLISH);
+        switch (lcResult) {
+            case "passed":
+                return success;
+            case "failed":
+                return failed;
+            case "cancelled":
+                return canceled;
+            default:
+                return pending;
+        }
+    }
+}

--- a/src/main/java/com/tw/go/plugin/provider/gitlab/GitLabProvider.java
+++ b/src/main/java/com/tw/go/plugin/provider/gitlab/GitLabProvider.java
@@ -1,0 +1,42 @@
+package com.tw.go.plugin.provider.gitlab;
+
+
+import com.tw.go.plugin.PluginSettings;
+import com.tw.go.plugin.provider.Provider;
+import com.tw.go.plugin.util.StringUtils;
+import org.gitlab.api.GitlabAPI;
+import org.gitlab.api.models.GitlabCommitStatus;
+import org.gitlab.api.models.GitlabProject;
+
+public class GitLabProvider implements Provider {
+    public static final String PLUGIN_ID = "gitlab.mr.status";
+    public static final String GITLAB_MR_POLLER_PLUGIN_ID = "gitlab.mr";
+
+    @Override
+    public String pluginId() {
+        return PLUGIN_ID;
+    }
+
+    @Override
+    public String pollerPluginId() {
+        return GITLAB_MR_POLLER_PLUGIN_ID;
+    }
+
+    @Override
+    public void updateStatus(String url, PluginSettings pluginSettings, String branch, String revision, String pipelineStage, String result, String trackbackURL) throws Exception {
+        final String groupAndProject = StringUtils.getRepository(url);
+        String endPointToUse = pluginSettings.getEndPoint();
+        String oauthAccessTokenToUse = pluginSettings.getOauthToken();
+
+        if (StringUtils.isEmpty(endPointToUse)) {
+            endPointToUse = System.getProperty("go.plugin.build.status.gitlab.endpoint");
+        }
+        if (StringUtils.isEmpty(oauthAccessTokenToUse)) {
+            oauthAccessTokenToUse = System.getProperty("go.plugin.build.status.gitlab.oauth");
+        }
+        final GitlabAPI api = GitlabAPI.connect(endPointToUse, oauthAccessTokenToUse);
+        final GitlabProject project = api.getProject(groupAndProject);
+        final String state = String.valueOf(GitLabCommitState.getState(result));
+        final GitlabCommitStatus commitStatus = api.createCommitStatus(project, revision, state, branch, pipelineStage, trackbackURL, "");
+    }
+}

--- a/src/main/java/com/tw/go/plugin/util/StringUtils.java
+++ b/src/main/java/com/tw/go/plugin/util/StringUtils.java
@@ -4,4 +4,24 @@ public class StringUtils {
     public static boolean isEmpty(String str) {
         return str == null || str.trim().isEmpty();
     }
+
+    /**
+     * Extract the group/project resp. organisation/repository path for GitLab and GitHub.
+     *
+     * @param url - "git@github.com:mfriedenhagen/gocd-build-status-notifier.git"
+     * @return - "mfriedenhagen/gocd-build-status-notifier"
+     */
+    public static String getRepository(String url) {
+        String[] urlParts = url.split("/");
+        String repo = urlParts[urlParts.length - 1];
+        String usernameWithSSHPrefix = urlParts[urlParts.length - 2];
+        int positionOfColon = usernameWithSSHPrefix.lastIndexOf(":");
+        if (positionOfColon > 0) {
+            usernameWithSSHPrefix = usernameWithSSHPrefix.substring(positionOfColon + 1);
+        }
+
+        String urlWithoutPrefix = String.format("%s/%s", usernameWithSSHPrefix, repo);
+        if (urlWithoutPrefix.endsWith(".git")) return urlWithoutPrefix.substring(0, urlWithoutPrefix.length() - 4);
+        else return urlWithoutPrefix;
+    }
 }

--- a/src/main/resources/gerrit/plugin.xml
+++ b/src/main/resources/gerrit/plugin.xml
@@ -7,7 +7,7 @@
         <description>Updates build status for Gerrit change set</description>
         <vendor>
             <name>Srinivas</name>
-            <url>https://github.com/srinivasupadhya/gocd-build-status-notifier</url>
+            <url>https://github.com/gocd-contrib/gocd-build-status-notifier/</url>
         </vendor>
     </about>
 </go-plugin>

--- a/src/main/resources/github/plugin.xml
+++ b/src/main/resources/github/plugin.xml
@@ -7,7 +7,7 @@
         <description>Updates build status for GitHub pull request</description>
         <vendor>
             <name>Srinivas Upadhya</name>
-            <url>https://github.com/srinivasupadhya/gocd-build-status-notifier</url>
+            <url>https://github.com/gocd-contrib/gocd-build-status-notifier/</url>
         </vendor>
     </about>
 </go-plugin>

--- a/src/main/resources/gitlab/defaults.properties
+++ b/src/main/resources/gitlab/defaults.properties
@@ -1,0 +1,1 @@
+provider=com.tw.go.plugin.provider.gitlab.GitLabProvider

--- a/src/main/resources/gitlab/plugin.xml
+++ b/src/main/resources/gitlab/plugin.xml
@@ -6,8 +6,8 @@
         <target-go-version>${go.version}</target-go-version>
         <description>Updates build status for GitLab Merge request</description>
         <vendor>
-            <name>Srinivas Upadhya</name>
-            <url>https://github.com/srinivasupadhya/gocd-build-status-notifier</url>
+            <name>Mirko Friedenhagen</name>
+            <url>https://github.com/gocd-contrib/gocd-build-status-notifier/</url>
         </vendor>
     </about>
 </go-plugin>

--- a/src/main/resources/gitlab/plugin.xml
+++ b/src/main/resources/gitlab/plugin.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<go-plugin id="github.pr.status" version="1">
+<go-plugin id="gitlab.mr.status" version="1">
     <about>
-        <name>Github Pull Requests status notifier</name>
+        <name>GitLab Merge Requests status notifier</name>
         <version>${project.version}</version>
         <target-go-version>${go.version}</target-go-version>
-        <description>Updates build status for GitHub pull request</description>
+        <description>Updates build status for GitLab Merge request</description>
         <vendor>
             <name>Srinivas Upadhya</name>
             <url>https://github.com/srinivasupadhya/gocd-build-status-notifier</url>

--- a/src/main/resources/stash/plugin.xml
+++ b/src/main/resources/stash/plugin.xml
@@ -7,7 +7,7 @@
         <description>Updates build status for Stash pull request</description>
         <vendor>
             <name>Srinivas</name>
-            <url>https://github.com/srinivasupadhya/gocd-build-status-notifier</url>
+            <url>https://github.com/gocd-contrib/gocd-build-status-notifier/</url>
         </vendor>
     </about>
 </go-plugin>

--- a/src/main/resources/stash/plugin.xml
+++ b/src/main/resources/stash/plugin.xml
@@ -2,8 +2,8 @@
 <go-plugin id="stash.pr.status" version="1">
     <about>
         <name>Stash Pull Requests status notifier</name>
-        <version>0.1</version>
-        <target-go-version>15.1.0</target-go-version>
+        <version>${project.version}</version>
+        <target-go-version>${go.version}</target-go-version>
         <description>Updates build status for Stash pull request</description>
         <vendor>
             <name>Srinivas</name>

--- a/src/test/java/com/tw/go/plugin/provider/github/GitHubProviderTest.java
+++ b/src/test/java/com/tw/go/plugin/provider/github/GitHubProviderTest.java
@@ -1,6 +1,7 @@
 package com.tw.go.plugin.provider.github;
 
 import com.tw.go.plugin.PluginSettings;
+import com.tw.go.plugin.util.StringUtils;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -17,19 +18,6 @@ public class GitHubProviderTest {
     public void setUp() throws Exception {
         pluginSettings = new PluginSettings();
         provider = new GitHubProvider();
-    }
-
-    @Test
-    public void shouldGetRepositoryFromURL() {
-        assertThat(provider.getRepository("http://github.com/srinivasupadhya/sample-repo"), is("srinivasupadhya/sample-repo"));
-        assertThat(provider.getRepository("http://github.com/srinivasupadhya/sample-repo.git"), is("srinivasupadhya/sample-repo"));
-        assertThat(provider.getRepository("http://github.com/srinivasupadhya/sample-repo/"), is("srinivasupadhya/sample-repo"));
-        assertThat(provider.getRepository("http://github.com/srinivasupadhya/sample-repo.git/"), is("srinivasupadhya/sample-repo"));
-        assertThat(provider.getRepository("https://github.com/srinivasupadhya/sample-repo"), is("srinivasupadhya/sample-repo"));
-        assertThat(provider.getRepository("https://github.com/srinivasupadhya/sample-repo.git"), is("srinivasupadhya/sample-repo"));
-        assertThat(provider.getRepository("git@code.corp.yourcompany.com:srinivasupadhya/sample-repo"), is("srinivasupadhya/sample-repo"));
-        assertThat(provider.getRepository("git@code.corp.yourcompany.com:srinivasupadhya/sample-repo.git"), is("srinivasupadhya/sample-repo"));
-        assertThat(provider.getRepository("git@github.com:srinivasupadhya/sample-repo.git"), is("srinivasupadhya/sample-repo"));
     }
 
     @Test

--- a/src/test/java/com/tw/go/plugin/provider/gitlab/GitLabCommitStateTest.java
+++ b/src/test/java/com/tw/go/plugin/provider/gitlab/GitLabCommitStateTest.java
@@ -1,0 +1,23 @@
+package com.tw.go.plugin.provider.gitlab;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class GitLabCommitStateTest {
+
+    @Test
+    public void shouldGetStateFromResult() {
+        assertThat(GitLabCommitState.getState("Passed"), is(GitLabCommitState.success));
+        assertThat(GitLabCommitState.getState("fAiled"), is(GitLabCommitState.failed));
+        assertThat(GitLabCommitState.getState("Cancelled"), is(GitLabCommitState.canceled));
+        assertThat(GitLabCommitState.getState(""), is(GitLabCommitState.pending));
+        assertThat(GitLabCommitState.getState(null), is(GitLabCommitState.pending));
+    }
+
+    @Test
+    public void shouldLowerCaseState() {
+        assertThat(String.valueOf(GitLabCommitState.getState(null)), is("pending"));
+    }
+}

--- a/src/test/java/com/tw/go/plugin/provider/gitlab/GitLabProviderTest.java
+++ b/src/test/java/com/tw/go/plugin/provider/gitlab/GitLabProviderTest.java
@@ -1,0 +1,20 @@
+package com.tw.go.plugin.provider.gitlab;
+
+import com.tw.go.plugin.PluginSettings;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GitLabProviderTest {
+    final PluginSettings pluginSettings = new PluginSettings();
+    final GitLabProvider provider = new GitLabProvider();
+
+    @Test
+    @Ignore("local run only")
+    public void testUpdateStatus() throws Exception {
+        pluginSettings.setEndPoint("https://gitlab.com/");
+        provider.updateStatus("ssh://git@gitlab.com/mfriedenhagen/gocd-notifier-test.git", pluginSettings, "master", "73a655c60fd56b761334fe77d1814aa3344b4621", "pipeline-name/stage-name", "Passed", "http://localhost:8153/go/pipelines/pipeline-name/1/stage-name/1");
+        provider.updateStatus("ssh://git@gitlab.com/mfriedenhagen/gocd-notifier-test.git", pluginSettings, "feature/1234", "f9c399ef9e7f0d242106db323a9afe00c0cb89a0", "pipeline-name/stage-name", "Passed", "http://localhost:8153/go/pipelines/pipeline-name/1/stage-name/1");
+    }
+}

--- a/src/test/java/com/tw/go/plugin/util/StringUtilsTest.java
+++ b/src/test/java/com/tw/go/plugin/util/StringUtilsTest.java
@@ -1,0 +1,33 @@
+package com.tw.go.plugin.util;
+
+import org.junit.Test;
+
+import static com.tw.go.plugin.util.StringUtils.getRepository;
+import static com.tw.go.plugin.util.StringUtils.isEmpty;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class StringUtilsTest {
+
+    @Test
+    public void testIsEmpty() throws Exception {
+        assertTrue(isEmpty(null));
+        assertTrue(isEmpty(""));
+        assertFalse(isEmpty("Hello"));
+    }
+
+    @Test
+    public void shouldGetRepositoryFromURL() {
+        assertThat(getRepository("http://github.com/srinivasupadhya/sample-repo"), is("srinivasupadhya/sample-repo"));
+        assertThat(getRepository("http://github.com/srinivasupadhya/sample-repo.git"), is("srinivasupadhya/sample-repo"));
+        assertThat(getRepository("http://github.com/srinivasupadhya/sample-repo/"), is("srinivasupadhya/sample-repo"));
+        assertThat(getRepository("http://github.com/srinivasupadhya/sample-repo.git/"), is("srinivasupadhya/sample-repo"));
+        assertThat(getRepository("https://github.com/srinivasupadhya/sample-repo"), is("srinivasupadhya/sample-repo"));
+        assertThat(getRepository("https://github.com/srinivasupadhya/sample-repo.git"), is("srinivasupadhya/sample-repo"));
+        assertThat(getRepository("git@code.corp.yourcompany.com:srinivasupadhya/sample-repo"), is("srinivasupadhya/sample-repo"));
+        assertThat(getRepository("git@code.corp.yourcompany.com:srinivasupadhya/sample-repo.git"), is("srinivasupadhya/sample-repo"));
+        assertThat(getRepository("git@github.com:srinivasupadhya/sample-repo.git"), is("srinivasupadhya/sample-repo"));
+        assertThat(getRepository("ssh://git@gitlab.com/srinivasupadhya/sample-repo.git"), is("srinivasupadhya/sample-repo"));
+    }
+
+}


### PR DESCRIPTION
Implement GitLabProvider for notifications from e.g. Merge-Requests.
- Switched to project to JDK 7 (Could do with 6, but not being able
  to switch over a String feels very old-fashioned).
- Updated the go.version in the POM to the one found in the
  plugin.xml files and plugin version as well as go.version are
  now injected during filtering for consistency.
- Moved function getRepository from GitHubProvider to StringUtils
  because GH and GL are similar in this regards.
