### PR TITLE
Added a maven.resources.overwrite=true flag to ensure that the correct plugin.xml are packaged for the jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,12 +58,10 @@
     <profiles>
         <profile>
             <id>github.pr.status</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <properties>
                 <plugin.name>github-pr-status</plugin.name>
                 <resource.directory>src/main/resources/github</resource.directory>
+                <maven.resources.overwrite>true</maven.resources.overwrite> 
             </properties>
         </profile>
         <profile>
@@ -71,6 +69,7 @@
             <properties>
                 <plugin.name>stash-pr-status</plugin.name>
                 <resource.directory>src/main/resources/stash</resource.directory>
+                <maven.resources.overwrite>true</maven.resources.overwrite> 
             </properties>
         </profile>
         <profile>
@@ -78,6 +77,7 @@
             <properties>
                 <plugin.name>gerrit-cs-status</plugin.name>
                 <resource.directory>src/main/resources/gerrit</resource.directory>
+                <maven.resources.overwrite>true</maven.resources.overwrite> 
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
Before this, a command like 'mvn clean package -P github.pr.status && mvn package -P gerrit.cs.status' would generate two jars but include the plugin xml for github in both of them.
This causes the stash and gerrit plugin to not work at all