### PR TITLE
Bump up version for the plugin as well as Go version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tw.go.plugin</groupId>
     <artifactId>gocd-build-status-notifier</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <go.version>14.4.0</go.version>
+        <go.version>17.3.0</go.version>
         <main.dir>${project.basedir}</main.dir>
     </properties>
 
@@ -83,7 +83,7 @@
     </profiles>
 
     <build>
-        <finalName>${plugin.name}-${version}</finalName>
+        <finalName>${plugin.name}-${project.version}</finalName>
         <resources>
             <resource>
                 <directory>${resource.directory}</directory>

--- a/src/main/resources/gerrit/plugin.xml
+++ b/src/main/resources/gerrit/plugin.xml
@@ -2,8 +2,8 @@
 <go-plugin id="gerrit.cs.status" version="1">
     <about>
         <name>Gerrit Change Set status notifier</name>
-        <version>1.2</version>
-        <target-go-version>15.1.0</target-go-version>
+        <version>1.3</version>
+        <target-go-version>17.3.0</target-go-version>
         <description>Updates build status for Gerrit change set</description>
         <vendor>
             <name>Srinivas</name>

--- a/src/main/resources/github/plugin.xml
+++ b/src/main/resources/github/plugin.xml
@@ -2,8 +2,8 @@
 <go-plugin id="github.pr.status" version="1">
     <about>
         <name>Github Pull Requests status notifier</name>
-        <version>1.2</version>
-        <target-go-version>15.1.0</target-go-version>
+        <version>1.3</version>
+        <target-go-version>17.3.0</target-go-version>
         <description>Updates build status for GitHub pull request</description>
         <vendor>
             <name>Srinivas Upadhya</name>

--- a/src/main/resources/stash/plugin.xml
+++ b/src/main/resources/stash/plugin.xml
@@ -2,8 +2,8 @@
 <go-plugin id="stash.pr.status" version="1">
     <about>
         <name>Stash Pull Requests status notifier</name>
-        <version>1.2</version>
-        <target-go-version>15.1.0</target-go-version>
+        <version>1.3</version>
+        <target-go-version>17.3.0</target-go-version>
         <description>Updates build status for Stash pull request</description>
         <vendor>
             <name>Srinivas</name>


### PR DESCRIPTION
To be merged only after 17.3.0 release as this has a dependency on `cd.go.plugin:go-plugin-api:jar:17.3.0` which would be published to maven central only after a release.