### PR TITLE
Fix interpolation in log messages

### DIFF
--- a/github-pr-status/src/main/java/com/tw/go/plugin/provider/GitHubProvider.java
+++ b/github-pr-status/src/main/java/com/tw/go/plugin/provider/GitHubProvider.java
@@ -50,7 +50,7 @@ public class GitHubProvider extends DefaultProvider {
     @Override
     public void updateStatus(String url, PluginSettings pluginSettings, String prIdStr, String revision, String pipelineStage,
                              String result, String trackbackURL) throws Exception {
-        LOGGER.info("Updating status for '%s' to %s", url, result);
+        LOGGER.info("Updating status for '{}' to '{}'", url, result);
 
         String repository = getRepository(url);
         GHCommitState state = getState(result);
@@ -85,7 +85,7 @@ public class GitHubProvider extends DefaultProvider {
 
     void updateCommitStatus(String revision, String pipelineStage, String trackbackURL, String repository, GHCommitState state,
                             String usernameToUse, String passwordToUse, String oauthAccessTokenToUse, String endPointToUse) throws Exception {
-        LOGGER.info("Updating commit status for '%s' on '%s'", revision, pipelineStage);
+        LOGGER.info("Updating commit status for '{}' on '{}'", revision, pipelineStage);
 
         GitHub github = createGitHubClient(usernameToUse, passwordToUse, oauthAccessTokenToUse, endPointToUse);
         GHRepository ghRepository = github.getRepository(repository);
@@ -117,7 +117,7 @@ public class GitHubProvider extends DefaultProvider {
     }
 
     public String getRepository(String url) {
-        LOGGER.info("Getting repository '%s'", url);
+        LOGGER.info("Getting repository '{}'", url);
 
         String[] urlParts = url.split("/");
         String repo = urlParts[urlParts.length - 1];


### PR DESCRIPTION
Currently these logs are printed literally, i.e. `Updating status for '%s' to %s`

SLF4J expects braces to be used for parametised logging: https://www.slf4j.org/faq.html#logging_performance